### PR TITLE
Fix hero image proportions on desktop

### DIFF
--- a/css/home.css
+++ b/css/home.css
@@ -2,6 +2,10 @@
   padding-block: clamp(5rem, 3vw, 9rem);
 }
 
+.hero--home .hero__image {
+  --hero-image-ratio: 4 / 3;
+}
+
 .values-grid {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));

--- a/css/main.css
+++ b/css/main.css
@@ -47,6 +47,10 @@ svg {
   display: block;
 }
 
+img {
+  height: auto;
+}
+
 a {
   color: inherit;
   text-decoration: none;
@@ -396,6 +400,7 @@ main {
   border-radius: var(--radius-lg);
   overflow: hidden;
   box-shadow: var(--shadow-lg);
+  aspect-ratio: var(--hero-image-ratio, 4 / 5);
 }
 
 .hero__image img {


### PR DESCRIPTION
## Summary
- ensure global images keep their intrinsic aspect ratio by default to avoid stretching
- add a configurable aspect ratio for hero visuals and align the home page hero with its landscape asset

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68de59229d988330bc6dc020b240ca28